### PR TITLE
Changes `callback` -> `cb` in auth config

### DIFF
--- a/config/auth.js
+++ b/config/auth.js
@@ -12,7 +12,7 @@ function validate(decoded, token, cb) {
 
     if (decoded.authLink) {
         if (diff > ttl) {
-            return callback(null, false);
+            return cb(null, false);
         }
 
         User.findOne({_id: decoded.id}, (err, user) => {


### PR DESCRIPTION
If the `diff` time was beyond the time out value, `callback` was being called, which is not defined. Changed it to use the `cb` param.
